### PR TITLE
Add invalid reservationID test for deleteReservation method

### DIFF
--- a/src/test/java/com/tomdaly/hotel/web/application/ReservationControllerTest.java
+++ b/src/test/java/com/tomdaly/hotel/web/application/ReservationControllerTest.java
@@ -127,4 +127,41 @@ public class ReservationControllerTest {
         .andExpect(status().isFound())
         .andExpect(flash().attribute("deleteMessage", "Reservation deleted"));
   }
+
+
+  @Test
+  public void testDeleteReservation_onInvalidRoomId_shouldReturnInvalidReservationIdMessage() throws Exception {
+    this.mockMvc
+            .perform(
+                    post("/reservations/delete")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .content(
+                                    buildUrlEncodedFormEntity(
+                                            "roomId",
+                                            "invalid room id",
+                                            "guestId",
+                                            "1",
+                                            "date",
+                                            "2019-01-01")))
+            .andExpect(status().isFound())
+            .andExpect(flash().attribute("deleteMessage", "Invalid reservation ID"));
+  }
+
+  @Test
+  public void testDeleteReservation_onInvalidGuestId_shouldReturnInvalidReservationIdMessage() throws Exception {
+    this.mockMvc
+            .perform(
+                    post("/reservations/delete")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .content(
+                                    buildUrlEncodedFormEntity(
+                                            "roomId",
+                                            "1",
+                                            "guestId",
+                                            "invalid guest id",
+                                            "date",
+                                            "2019-01-01")))
+            .andExpect(status().isFound())
+            .andExpect(flash().attribute("deleteMessage", "Invalid reservation ID"));
+  }
 }

--- a/src/test/java/com/tomdaly/hotel/web/service/ReservationServiceControllerTest.java
+++ b/src/test/java/com/tomdaly/hotel/web/service/ReservationServiceControllerTest.java
@@ -79,4 +79,20 @@ public class ReservationServiceControllerTest {
         .andExpect(status().isOk())
         .andExpect(content().string(containsString("Reservation deleted")));
   }
+
+  @Test
+  public void testApiDeleteReservation_onInvalidRoomId_shouldReturnInvalidReservationIdMessage() throws Exception {
+    this.mockMvc
+            .perform(get("/api/reservations/delete/invalidId/1/2019-01-01"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("Invalid reservation ID")));
+  }
+
+  @Test
+  public void testApiDeleteReservation_onInvalidGuestId_shouldReturnInvalidReservationIdMessage() throws Exception {
+    this.mockMvc
+            .perform(get("/api/reservations/delete/1/invalidId/2019-01-01"))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("Invalid reservation ID")));
+  }
 }


### PR DESCRIPTION
Add unit tests for ReservationController and ReservationServiceController
to cover the exception handling in the try-catch block for an invalid
room or guest ID