### PR TITLE
Delete profanity set

### DIFF
--- a/src/main/java/com/tomdaly/hotel/business/service/ProfanityService.java
+++ b/src/main/java/com/tomdaly/hotel/business/service/ProfanityService.java
@@ -109,6 +109,18 @@ public class ProfanityService {
     return profanitySet;
   }
 
+  public String deleteProfanitySet(String name) {
+    ProfanitySet profanitySet = profanitySetRepository.findByName(name);
+    if (profanitySet == null) {
+      return "Could not delete profanity set '" + name + "'";
+    }
+    try {
+      this.profanitySetRepository.delete(profanitySet);
+      return "Profanity set '" + name + "' deleted";
+    } catch (DataIntegrityViolationException e) {
+      return "Could not delete profanity set '" + name + "'";
+    }
+  }
 
   public List<ProfanitySet> getProfanitySets() {
     return this.profanitySets;

--- a/src/main/java/com/tomdaly/hotel/business/service/ProfanityService.java
+++ b/src/main/java/com/tomdaly/hotel/business/service/ProfanityService.java
@@ -48,18 +48,27 @@ public class ProfanityService {
   }
 
   @Loggable
-  public ProfanitySet deleteProfanityFromSet(String word, ProfanitySet profanitySet) {
-    Profanity profanity = this.profanityRepository.findByWord(word);
-    if (profanity == null) {
-      return profanitySet;
+  public String deleteProfanityFromSet(String word, ProfanitySet profanitySet) {
+    Profanity profanity = findProfanity(word);
+    if (!profanity.getWord().equals("")) {
+      try {
+        profanitySet.deleteProfanity(profanity);
+        this.profanitySetRepository.save(profanitySet);
+        return "Deleted profanity '" + word + "' from set '" + profanitySet.getName() + "'";
+      } catch (DataIntegrityViolationException e) {
+        return "Could not delete profanity '"
+            + word
+            + "' from set '"
+            + profanitySet.getName()
+            + "'";
+      }
     }
-    try {
-      profanitySet.deleteProfanity(profanity);
-      this.profanitySetRepository.save(profanitySet);
-      return profanitySet;
-    } catch (DataIntegrityViolationException e) {
-      return profanitySet;
-    }
+    return "Profanity '" + word + "' not found in set '" + profanitySet.getName() + "'";
+  }
+
+  private Profanity findProfanity(String word) {
+    Profanity profanity = profanityRepository.findByWord(word);
+    return profanity != null ? profanity : new Profanity();
   }
 
   @Loggable

--- a/src/main/java/com/tomdaly/hotel/business/service/ProfanityService.java
+++ b/src/main/java/com/tomdaly/hotel/business/service/ProfanityService.java
@@ -110,16 +110,21 @@ public class ProfanityService {
   }
 
   public String deleteProfanitySet(String name) {
+    ProfanitySet profanitySet = findProfanitySet(name);
+    if (!profanitySet.getName().equals("")) {
+      try {
+        this.profanitySetRepository.delete(profanitySet);
+        return "Profanity set '" + name + "' deleted";
+      } catch (DataIntegrityViolationException e) {
+        return "Could not delete profanity set '" + name + "'";
+      }
+    }
+    return "Profanity set '" + name + "' not found";
+  }
+
+  private ProfanitySet findProfanitySet(String name) {
     ProfanitySet profanitySet = profanitySetRepository.findByName(name);
-    if (profanitySet == null) {
-      return "Could not delete profanity set '" + name + "'";
-    }
-    try {
-      this.profanitySetRepository.delete(profanitySet);
-      return "Profanity set '" + name + "' deleted";
-    } catch (DataIntegrityViolationException e) {
-      return "Could not delete profanity set '" + name + "'";
-    }
+    return profanitySet != null ? profanitySet : new ProfanitySet();
   }
 
   public List<ProfanitySet> getProfanitySets() {

--- a/src/main/java/com/tomdaly/hotel/data/repository/ProfanitySetRepository.java
+++ b/src/main/java/com/tomdaly/hotel/data/repository/ProfanitySetRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProfanitySetRepository extends CrudRepository<ProfanitySet, Long> {}
+public interface ProfanitySetRepository extends CrudRepository<ProfanitySet, Long> {
+    ProfanitySet findByName(String name);
+}

--- a/src/main/java/com/tomdaly/hotel/data/repository/ProfanitySetRepository.java
+++ b/src/main/java/com/tomdaly/hotel/data/repository/ProfanitySetRepository.java
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProfanitySetRepository extends CrudRepository<ProfanitySet, Long> {
-    ProfanitySet findByName(String name);
+  ProfanitySet findByName(String name);
 }

--- a/src/main/java/com/tomdaly/hotel/web/service/ProfanityServiceController.java
+++ b/src/main/java/com/tomdaly/hotel/web/service/ProfanityServiceController.java
@@ -48,4 +48,9 @@ public class ProfanityServiceController {
   public ProfanitySet createProfanitySet(@RequestParam("name") String profanitySetName) {
     return this.profanityService.createProfanitySet(profanitySetName);
   }
+
+  @RequestMapping(method = RequestMethod.DELETE, value = "/profanity/sets")
+  public String deleteProfanitySet(@RequestParam("name") String profanitySetName) {
+    return this.profanityService.deleteProfanitySet(profanitySetName);
+  }
 }

--- a/src/main/java/com/tomdaly/hotel/web/service/ProfanityServiceController.java
+++ b/src/main/java/com/tomdaly/hotel/web/service/ProfanityServiceController.java
@@ -28,7 +28,7 @@ public class ProfanityServiceController {
   }
 
   @RequestMapping(method = RequestMethod.DELETE, value = "/profanity/delete")
-  public ProfanitySet deleteProfanityFromSet(
+  public String deleteProfanityFromSet(
       @RequestParam("set") String profanitySetName, @RequestParam("word") String word) {
     ProfanitySet profanitySet;
     for (ProfanitySet profanitySetIter : profanityService.getProfanitySets()) {
@@ -36,12 +36,12 @@ public class ProfanityServiceController {
         return this.profanityService.deleteProfanityFromSet(word, profanitySet);
       }
     }
-    return new ProfanitySet();
+    return "Profanity set '" + profanitySetName + "' not found";
   }
 
   @RequestMapping(method = RequestMethod.GET, value = "/profanity/sets")
   public List<ProfanitySet> getProfanitySets() {
-      return this.profanityService.getProfanitySets();
+    return this.profanityService.getProfanitySets();
   }
 
   @RequestMapping(method = RequestMethod.POST, value = "/profanity/sets")

--- a/src/test/java/com/tomdaly/hotel/business/service/ProfanityServiceTest.java
+++ b/src/test/java/com/tomdaly/hotel/business/service/ProfanityServiceTest.java
@@ -22,7 +22,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.when;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 public class ProfanityServiceTest {
@@ -62,31 +61,28 @@ public class ProfanityServiceTest {
 
   @Test
   public void
-      testDeleteProfanityFromSet_givenExistingProfanityAndExistingSet_shouldReturnSetWithoutWord() {
+      testDeleteProfanityFromSet_givenExistingProfanityAndExistingSet_shouldReturnDeleteSuccessMessage() {
     Profanity mockProfanity = new Profanity("foobar");
     ProfanitySet testProfanitySet = new ProfanitySet("test");
     testProfanitySet.addProfanity(mockProfanity);
     given(profanityRepository.findByWord("foobar")).willReturn(mockProfanity);
     doNothing().when(profanityRepository).delete(mockProfanity);
-    ProfanitySet returnedProfanitySet =
-        profanityService.deleteProfanityFromSet("foobar", testProfanitySet);
-    ProfanitySet expectedProfanitySet = new ProfanitySet("test");
-    assertThat(returnedProfanitySet, is(equalTo(expectedProfanitySet)));
+    assertThat(
+        profanityService.deleteProfanityFromSet("foobar", testProfanitySet),
+        is(equalTo("Deleted profanity 'foobar' from set 'test'")));
   }
 
   @Test
-  public void testDeleteProfanity_givenNonexistentProfanity_shouldReturnUnchangedSet() {
-    Profanity mockProfanity = new Profanity("notFoobar");
+  public void testDeleteProfanity_givenNonexistentProfanity_shouldReturnProfanityNotFoundMessage() {
+    Profanity mockProfanity = new Profanity("foobar");
     ProfanitySet testProfanitySet = new ProfanitySet("test");
-    testProfanitySet.addProfanity(mockProfanity);
     given(profanityRepository.findByWord("foobar")).willReturn(null);
     willThrow(DataIntegrityViolationException.class)
         .given(profanityRepository)
         .delete(mockProfanity);
-    ProfanitySet returnedProfanitySet =
-        profanityService.deleteProfanityFromSet("foobar", testProfanitySet);
-    ProfanitySet expectedProfanitySet = testProfanitySet;
-    assertThat(returnedProfanitySet, is(equalTo(expectedProfanitySet)));
+    assertThat(
+        profanityService.deleteProfanityFromSet("foobar", testProfanitySet),
+        is(equalTo("Profanity 'foobar' not found in set 'test'")));
   }
 
   @Test
@@ -149,13 +145,15 @@ public class ProfanityServiceTest {
     ProfanitySet testProfanitySet = new ProfanitySet("test");
     given(profanitySetRepository.findByName("test")).willReturn(testProfanitySet);
     doNothing().when(profanitySetRepository).delete(testProfanitySet);
-    assertThat(profanityService.deleteProfanitySet("test"), is(equalTo("Profanity set 'test' deleted")));
+    assertThat(
+        profanityService.deleteProfanitySet("test"), is(equalTo("Profanity set 'test' deleted")));
   }
 
   @Test
   public void testDeleteProfanitySet_givenNonexistentProfanitySet_shouldReturnNotFoundMessage() {
     given(profanitySetRepository.findByName("test")).willReturn(null);
-    assertThat(profanityService.deleteProfanitySet("test"), is(equalTo("Profanity set 'test' not found")));
+    assertThat(
+        profanityService.deleteProfanitySet("test"), is(equalTo("Profanity set 'test' not found")));
   }
 
   @Test
@@ -163,8 +161,9 @@ public class ProfanityServiceTest {
     ProfanitySet testProfanitySet = new ProfanitySet("invalid");
     given(profanitySetRepository.findByName("test")).willReturn(null);
     willThrow(DataIntegrityViolationException.class)
-            .given(profanitySetRepository)
-            .delete(testProfanitySet);
-    assertThat(profanityService.deleteProfanitySet("test"), is(equalTo("Profanity set 'test' not found")));
+        .given(profanitySetRepository)
+        .delete(testProfanitySet);
+    assertThat(
+        profanityService.deleteProfanitySet("test"), is(equalTo("Profanity set 'test' not found")));
   }
 }

--- a/src/test/java/com/tomdaly/hotel/business/service/ProfanityServiceTest.java
+++ b/src/test/java/com/tomdaly/hotel/business/service/ProfanityServiceTest.java
@@ -153,8 +153,18 @@ public class ProfanityServiceTest {
   }
 
   @Test
-  public void testDeleteProfanitySet_givenNonexistentProfanitySet_shouldReturnDeleteFailedMessage() {
+  public void testDeleteProfanitySet_givenNonexistentProfanitySet_shouldReturnNotFoundMessage() {
     given(profanitySetRepository.findByName("test")).willReturn(null);
-    assertThat(profanityService.deleteProfanitySet("test"), is(equalTo("Could not delete profanity set 'test'")));
+    assertThat(profanityService.deleteProfanitySet("test"), is(equalTo("Profanity set 'test' not found")));
+  }
+
+  @Test
+  public void testDeleteProfanitySet_givenInvalidProfanitySet_shouldReturnDeleteFailedMessage() {
+    ProfanitySet testProfanitySet = new ProfanitySet("invalid");
+    given(profanitySetRepository.findByName("test")).willReturn(null);
+    willThrow(DataIntegrityViolationException.class)
+            .given(profanitySetRepository)
+            .delete(testProfanitySet);
+    assertThat(profanityService.deleteProfanitySet("test"), is(equalTo("Profanity set 'test' not found")));
   }
 }

--- a/src/test/java/com/tomdaly/hotel/business/service/ProfanityServiceTest.java
+++ b/src/test/java/com/tomdaly/hotel/business/service/ProfanityServiceTest.java
@@ -143,4 +143,18 @@ public class ProfanityServiceTest {
     ProfanitySet returnedProfanitySet = profanityService.createProfanitySet("");
     assertThat(returnedProfanitySet, is(equalTo(expectedProfanitySet)));
   }
+
+  @Test
+  public void testDeleteProfanitySet_givenExistingProfanitySet_shouldReturnDeleteSuccessMessage() {
+    ProfanitySet testProfanitySet = new ProfanitySet("test");
+    given(profanitySetRepository.findByName("test")).willReturn(testProfanitySet);
+    doNothing().when(profanitySetRepository).delete(testProfanitySet);
+    assertThat(profanityService.deleteProfanitySet("test"), is(equalTo("Profanity set 'test' deleted")));
+  }
+
+  @Test
+  public void testDeleteProfanitySet_givenNonexistentProfanitySet_shouldReturnDeleteFailedMessage() {
+    given(profanitySetRepository.findByName("test")).willReturn(null);
+    assertThat(profanityService.deleteProfanitySet("test"), is(equalTo("Could not delete profanity set 'test'")));
+  }
 }

--- a/src/test/java/com/tomdaly/hotel/web/service/ProfanityServiceControllerTest.java
+++ b/src/test/java/com/tomdaly/hotel/web/service/ProfanityServiceControllerTest.java
@@ -75,48 +75,37 @@ public class ProfanityServiceControllerTest {
 
   @Test
   public void
-      testApiDeleteProfanityFromSet_givenExistingProfanityAndExistingSet_shouldReturnProfanitySetWithoutGivenProfanity()
+      testApiDeleteProfanityFromSet_givenExistingProfanityAndExistingSet_shouldReturnDeleteSuccessMessage()
           throws Exception {
     Profanity testProfanityOne = new Profanity("foobar");
-    Profanity testProfanityTwo = new Profanity("notDeleted");
     ProfanitySet testProfanitySet = new ProfanitySet("test");
     testProfanitySet.addProfanity(testProfanityOne);
-    testProfanitySet.addProfanity(testProfanityTwo);
-    ProfanitySet expectedProfanitySet = new ProfanitySet();
-    expectedProfanitySet.addProfanity(testProfanityTwo);
     List<ProfanitySet> profanitySetsList = new ArrayList<>();
     profanitySetsList.add(testProfanitySet);
     given(profanityService.getProfanitySets()).willReturn(profanitySetsList);
     given(profanityService.deleteProfanityFromSet("foobar", testProfanitySet))
-        .willReturn(expectedProfanitySet);
+        .willReturn("Deleted profanity 'foobar' from set 'test");
     this.mockMvc
         .perform(
             delete("/api/profanity/delete")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .content(buildUrlEncodedFormEntity("set", "test", "word", "foobar")))
         .andExpect(status().isOk())
-        .andExpect(content().string(not(containsString("foobar"))))
-        .andExpect(content().string(containsString("notDeleted")));
+        .andExpect(content().string(containsString("Deleted profanity 'foobar' from set 'test")));
   }
 
   @Test
   public void
-      testApiDeleteProfanityFromSet_givenExistingProfanityAndNonexistentSet_shouldReturnEmptyProfanitySet()
+      testApiDeleteProfanityFromSet_givenExistingProfanityAndNonexistentSet_shouldReturnSetNotFoundMessage()
           throws Exception {
-    Profanity testProfanity = new Profanity("foobar");
-    ProfanitySet testProfanitySet = new ProfanitySet("test");
-    testProfanitySet.addProfanity(testProfanity);
-    ProfanitySet expectedProfanitySet = new ProfanitySet();
     given(profanityService.getProfanitySets()).willReturn(new ArrayList<>());
-    given(profanityService.deleteProfanityFromSet("foobar", testProfanitySet))
-        .willReturn(expectedProfanitySet);
     this.mockMvc
         .perform(
             delete("/api/profanity/delete")
                 .contentType(MediaType.APPLICATION_FORM_URLENCODED)
                 .content(buildUrlEncodedFormEntity("set", "test", "word", "foobar")))
         .andExpect(status().isOk())
-        .andExpect(content().string(not(containsString("foobar"))));
+        .andExpect(content().string(containsString("Profanity set 'test' not found")));
   }
 
   @Test
@@ -142,26 +131,31 @@ public class ProfanityServiceControllerTest {
   }
 
   @Test
-  public void testApiCreateProfanitySet_givenValidProfanitySetName_shouldReturnNewProfanitySetWithName() throws Exception {
+  public void
+      testApiCreateProfanitySet_givenValidProfanitySetName_shouldReturnNewProfanitySetWithName()
+          throws Exception {
     ProfanitySet testProfanitySet = new ProfanitySet("test");
     given(profanityService.createProfanitySet("test")).willReturn(testProfanitySet);
     this.mockMvc
-        .perform(post("/api/profanity/sets")
-        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-        .content(buildUrlEncodedFormEntity("name", "test")))
+        .perform(
+            post("/api/profanity/sets")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .content(buildUrlEncodedFormEntity("name", "test")))
         .andExpect(status().isOk())
         .andExpect(content().string(containsString("test")));
   }
 
   @Test
-  public void testApiCreateProfanitySet_givenInvalidProfanitySetName_shouldReturnEmptyProfanitySet() throws Exception {
+  public void testApiCreateProfanitySet_givenInvalidProfanitySetName_shouldReturnEmptyProfanitySet()
+      throws Exception {
     ProfanitySet testProfanitySet = new ProfanitySet();
     given(profanityService.createProfanitySet("_")).willReturn(testProfanitySet);
     this.mockMvc
-            .perform(post("/api/profanity/sets")
-            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-            .content(buildUrlEncodedFormEntity("name", "_")))
-            .andExpect(status().isOk())
-            .andExpect(content().string(not(containsString("_"))));
+        .perform(
+            post("/api/profanity/sets")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .content(buildUrlEncodedFormEntity("name", "_")))
+        .andExpect(status().isOk())
+        .andExpect(content().string(not(containsString("_"))));
   }
 }

--- a/src/test/java/com/tomdaly/hotel/web/service/ProfanityServiceControllerTest.java
+++ b/src/test/java/com/tomdaly/hotel/web/service/ProfanityServiceControllerTest.java
@@ -57,7 +57,6 @@ public class ProfanityServiceControllerTest {
   @Test
   public void testApiAddProfanityToSet_givenNewWordAndNonexistentSet_shouldReturnEmptyProfanitySet()
       throws Exception {
-    Profanity testProfanity = new Profanity("foobar");
     ProfanitySet testProfanitySet = new ProfanitySet("test");
     ProfanitySet expectedProfanitySet = new ProfanitySet();
 
@@ -77,9 +76,9 @@ public class ProfanityServiceControllerTest {
   public void
       testApiDeleteProfanityFromSet_givenExistingProfanityAndExistingSet_shouldReturnDeleteSuccessMessage()
           throws Exception {
-    Profanity testProfanityOne = new Profanity("foobar");
+    Profanity testProfanity = new Profanity("foobar");
     ProfanitySet testProfanitySet = new ProfanitySet("test");
-    testProfanitySet.addProfanity(testProfanityOne);
+    testProfanitySet.addProfanity(testProfanity);
     List<ProfanitySet> profanitySetsList = new ArrayList<>();
     profanitySetsList.add(testProfanitySet);
     given(profanityService.getProfanitySets()).willReturn(profanitySetsList);
@@ -106,6 +105,25 @@ public class ProfanityServiceControllerTest {
                 .content(buildUrlEncodedFormEntity("set", "test", "word", "foobar")))
         .andExpect(status().isOk())
         .andExpect(content().string(containsString("Profanity set 'test' not found")));
+  }
+
+  @Test
+  public void
+  testApiDeleteProfanityFromSet_givenNonexistentProfanityAndExistingSet_shouldReturnDeleteFailedMessage()
+          throws Exception {
+    ProfanitySet testProfanitySet = new ProfanitySet("test");
+    List<ProfanitySet> profanitySetsList = new ArrayList<>();
+    profanitySetsList.add(testProfanitySet);
+    given(profanityService.getProfanitySets()).willReturn(profanitySetsList);
+    given(profanityService.deleteProfanityFromSet("foobar", testProfanitySet))
+            .willReturn("Profanity 'foobar' not found in set 'test'");
+    this.mockMvc
+            .perform(
+                    delete("/api/profanity/delete")
+                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                            .content(buildUrlEncodedFormEntity("set", "test", "word", "foobar")))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("Profanity 'foobar' not found in set 'test'")));
   }
 
   @Test

--- a/src/test/java/com/tomdaly/hotel/web/service/ProfanityServiceControllerTest.java
+++ b/src/test/java/com/tomdaly/hotel/web/service/ProfanityServiceControllerTest.java
@@ -109,21 +109,21 @@ public class ProfanityServiceControllerTest {
 
   @Test
   public void
-  testApiDeleteProfanityFromSet_givenNonexistentProfanityAndExistingSet_shouldReturnDeleteFailedMessage()
+      testApiDeleteProfanityFromSet_givenNonexistentProfanityAndExistingSet_shouldReturnDeleteFailedMessage()
           throws Exception {
     ProfanitySet testProfanitySet = new ProfanitySet("test");
     List<ProfanitySet> profanitySetsList = new ArrayList<>();
     profanitySetsList.add(testProfanitySet);
     given(profanityService.getProfanitySets()).willReturn(profanitySetsList);
     given(profanityService.deleteProfanityFromSet("foobar", testProfanitySet))
-            .willReturn("Profanity 'foobar' not found in set 'test'");
+        .willReturn("Profanity 'foobar' not found in set 'test'");
     this.mockMvc
-            .perform(
-                    delete("/api/profanity/delete")
-                            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-                            .content(buildUrlEncodedFormEntity("set", "test", "word", "foobar")))
-            .andExpect(status().isOk())
-            .andExpect(content().string(containsString("Profanity 'foobar' not found in set 'test'")));
+        .perform(
+            delete("/api/profanity/delete")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .content(buildUrlEncodedFormEntity("set", "test", "word", "foobar")))
+        .andExpect(status().isOk())
+        .andExpect(content().string(containsString("Profanity 'foobar' not found in set 'test'")));
   }
 
   @Test
@@ -175,5 +175,32 @@ public class ProfanityServiceControllerTest {
                 .content(buildUrlEncodedFormEntity("name", "_")))
         .andExpect(status().isOk())
         .andExpect(content().string(not(containsString("_"))));
+  }
+
+  @Test
+  public void testApiDeleteProfanitySet_givenExistingProfanitySet_shouldReturnDeleteSuccessMessage()
+      throws Exception {
+    given(profanityService.deleteProfanitySet("test")).willReturn("Profanity set 'test' deleted");
+    this.mockMvc
+        .perform(
+            delete("/api/profanity/sets")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .content(buildUrlEncodedFormEntity("name", "test")))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Profanity set 'test' deleted"));
+  }
+
+  @Test
+  public void
+      testApiDeleteProfanitySet_givenNonexistentProfanitySet_shouldReturnDeleteFailedMessage()
+          throws Exception {
+    given(profanityService.deleteProfanitySet("test")).willReturn("Profanity set 'test' not found");
+    this.mockMvc
+        .perform(
+            delete("/api/profanity/sets")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                .content(buildUrlEncodedFormEntity("name", "test")))
+        .andExpect(status().isOk())
+        .andExpect(content().string("Profanity set 'test' not found"));
   }
 }


### PR DESCRIPTION
Allow deletion of profanity sets
Checks for valid profanity set name before deletion, handles exception of repository cannot delete the set
Also added API endpoint DELETE /profanity/sets to allow API deletion