### PR TITLE
Add test for deleteProfanity with invalid set, fix incorrect test

### DIFF
--- a/src/test/java/com/tomdaly/hotel/business/service/ProfanityServiceTest.java
+++ b/src/test/java/com/tomdaly/hotel/business/service/ProfanityServiceTest.java
@@ -74,15 +74,23 @@ public class ProfanityServiceTest {
 
   @Test
   public void testDeleteProfanity_givenNonexistentProfanity_shouldReturnProfanityNotFoundMessage() {
-    Profanity mockProfanity = new Profanity("foobar");
     ProfanitySet testProfanitySet = new ProfanitySet("test");
     given(profanityService.findProfanity("foobar")).willReturn(null);
-    willThrow(DataIntegrityViolationException.class)
-        .given(profanityRepository)
-        .delete(mockProfanity);
     assertThat(
         profanityService.deleteProfanityFromSet("foobar", testProfanitySet),
         is(equalTo("Profanity 'foobar' not found in set 'test'")));
+  }
+
+  @Test
+  public void testDeleteProfanity_givenExistingProfanityAndInvalidSet_shouldReturnProfanityNotFoundMessage() {
+    ProfanitySet testProfanitySet = new ProfanitySet("test");
+    given(profanityService.findProfanity("foobar")).willReturn(new Profanity("foobar"));
+    willThrow(DataIntegrityViolationException.class)
+            .given(profanitySetRepository)
+            .save(testProfanitySet);
+    assertThat(
+            profanityService.deleteProfanityFromSet("foobar", testProfanitySet),
+            is(equalTo("Could not delete profanity 'foobar' from set 'test'")));
   }
 
   @Test
@@ -177,12 +185,12 @@ public class ProfanityServiceTest {
 
   @Test
   public void testDeleteProfanitySet_givenInvalidProfanitySet_shouldReturnDeleteFailedMessage() {
-    ProfanitySet emptyProfanitySet = new ProfanitySet("");
-    given(profanityService.findProfanitySet("test")).willReturn(emptyProfanitySet);
+    ProfanitySet testProfanitySet = new ProfanitySet("invalid");
+    given(profanityService.findProfanitySet("test")).willReturn(testProfanitySet);
     willThrow(DataIntegrityViolationException.class)
         .given(profanitySetRepository)
-        .delete(emptyProfanitySet);
+        .delete(testProfanitySet);
     assertThat(
-        profanityService.deleteProfanitySet("test"), is(equalTo("Profanity set 'test' not found")));
+        profanityService.deleteProfanitySet("test"), is(equalTo("Could not delete profanity set 'test'")));
   }
 }


### PR DESCRIPTION
Added a new test for deleteProfanity if the set is invalid (ie. saving
the set in the repository throws an error)
Corrected the last test to ensure the exception is caught properly for
deleteProfanityFromSet with an invalid set
Removed unnecessary lines from deleteProfanity test with nonexistent
profanity